### PR TITLE
summaryH() now returns a summary.lm object 

### DIFF
--- a/R/summary_functions.R
+++ b/R/summary_functions.R
@@ -3,6 +3,7 @@
 #' This function displays regression results with standard errors adjusted for possible presence of heteroskedasticity using the method developed by White. This method is appropriate for cross-section data.
 #'
 #'@param model The linear regression model.
+#'@return sumry Returns a summary.lm object with Heteroscedasticity-consistent standard errors
 #'@export
 
 summaryH <- function(model) {
@@ -17,12 +18,12 @@ summaryH <- function(model) {
         lower.tail = FALSE)
 
     sumry$coefficients <- table
-    p <- nrow(table)
-    hyp <- cbind(0, diag(p - 1))
+    # p <- nrow(table)
+    # hyp <- cbind(0, diag(p - 1))
 
-    print(sumry, signif.stars = FALSE)
-    cat("Note: Heteroscedasticity-consistent standard errors")
-
+    # print(sumry, signif.stars = FALSE)
+    message("Generating summary with Heteroscedasticity-consistent standard errors")
+    return(sumry)
 }
 
 #' Summary of Regression (Time Series Data)

--- a/man/summaryH.Rd
+++ b/man/summaryH.Rd
@@ -9,6 +9,9 @@ summaryH(model)
 \arguments{
 \item{model}{The linear regression model.}
 }
+\value{
+sumry Returns a summary.lm object with Heteroscedasticity-consistent standard errors
+}
 \description{
 This function displays regression results with standard errors adjusted for possible presence of heteroskedasticity using the method developed by White. This method is appropriate for cross-section data.
 }


### PR DESCRIPTION
summaryH() now returns a summary.lm object. Previously, summaryH printed results and returned nothing. This new behavior is consistent with baseR's summary() fn.