### PR TITLE
Fix typo in hist_CI

### DIFF
--- a/R/hist_CI.R
+++ b/R/hist_CI.R
@@ -12,7 +12,7 @@
 
 hist_CI <- function(.data, alpha = .1, main = "Histogram", xlab = "Data and (1-alpha)% Confidence Interval", breaks = 20) {
   graphics::hist(.data,
-    breaks = 20, main = main, xlab = xlab,
+    breaks = breaks, main = main, xlab = xlab,
     col = "light blue"
   )
 


### PR DESCRIPTION
Fixed a problem where hist_CI does not generate histograms with the expected number of breaks